### PR TITLE
Fix history broken in the recent ACT version

### DIFF
--- a/overlay/index.html
+++ b/overlay/index.html
@@ -23,7 +23,7 @@ try {
     <script src="../share/lib/ws-abstract.js?v=viator-in-vitro"></script>
     <script src="../share/lib/locale.js?v=viator-in-vitro"></script>
     <script src="lib/render.js?v=viator-in-vitro"></script>
-    <script src="lib/listen.js?v=viator-in-vitro"></script>
+    <script src="lib/listen.js?v=viator-in-vitro-fix-history"></script>
     <script src="lib/ui.js?v=viator-in-vitro"></script>
     <script>
 // config

--- a/overlay/lib/listen.js
+++ b/overlay/lib/listen.js
@@ -131,7 +131,7 @@
     push(data) {
       if(!data || !data.Encounter || data.Encounter.hits < 1) return
 
-      if(this.isNewEncounter(data.Encounter)) {
+      if(this.isNewEncounter(data.Encounter, data.isActive)) {
         if(config.get('format.myname').length === 0
         && NICK_REGEX.test(data.Encounter.title)) {
           let nick = NICK_REGEX.exec(data.Encounter.title)[1]
@@ -158,25 +158,27 @@
       }
     }
 
-    updateLastEncounter(encounter) {
+    updateLastEncounter(encounter, isActive) {
       this.lastEncounter = {
         hits: encounter.hits,
         region: encounter.CurrentZoneName,
         damage: encounter.damage,
-        duration: parseInt(encounter.DURATION)
+        duration: parseInt(encounter.DURATION),
+        isActive: isActive
       }
     }
 
-    isNewEncounter(encounter) {
+    isNewEncounter(encounter, isActive) {
       let really = (
         !this.lastEncounter
       || this.lastEncounter.region !== encounter.CurrentZoneName
-      || this.lastEncounter.duration > parseInt(encounter.DURATION)
+      || this.lastEncounter.isActive !== isActive
       // ACT-side bug (scrambling data) making this invalid!
+      // || this.lastEncounter.duration > parseInt(encounter.DURATION)
       // || this.lastEncounter.damage > encounter.damage
       // || this.lastEncounter.hits > encounter.hits
       )
-      this.updateLastEncounter(encounter)
+      this.updateLastEncounter(encounter, isActive)
       return really
     }
 


### PR DESCRIPTION
Due to the combat data was processed multi-threaded in the recent ACT version, the data from overlay plugin no longer sequenced, which break the duration check of `isNewEncounter` method, so we use `isActive` there to check if it is an new encounter data.